### PR TITLE
Fixes failing model generation when using namedtuple type

### DIFF
--- a/edgedb_pydantic_codegen/models.py
+++ b/edgedb_pydantic_codegen/models.py
@@ -35,6 +35,18 @@ class EdgeQLLiteral:
 
 
 @dataclass
+class EdgeQLNamedTuple:
+    name: str
+    fields: list["EdgeQLNamedTupleField"] = dc_field(default_factory=list)
+
+
+@dataclass
+class EdgeQLNamedTupleField:
+    name: str
+    type_str: str
+
+
+@dataclass
 class EdgeQLModel:
     name: str
     fields: list["EdgeQLModelField"] = dc_field(default_factory=list)
@@ -59,6 +71,7 @@ class ProcessData:
     literals: dict[str, EdgeQLLiteral] = dc_field(default_factory=dict)
     enums: dict[str, EdgeQLEnum] = dc_field(default_factory=dict)
     models: dict[str, EdgeQLModel] = dc_field(default_factory=dict)
+    namedtuples: dict[str, EdgeQLNamedTuple] = dc_field(default_factory=dict)
     args: dict[str, EdgeQLArgument] = dc_field(default_factory=dict)
     optional_args: dict[str, EdgeQLArgument] = dc_field(default_factory=dict)
     return_type: str = "None"

--- a/edgedb_pydantic_codegen/template.py.jinja
+++ b/edgedb_pydantic_codegen/template.py.jinja
@@ -8,7 +8,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import date
 from datetime import time
-from typing import Any
+from typing import Any, NamedTuple
 
 from typing import Literal
 from enum import StrEnum
@@ -30,6 +30,13 @@ class {{enum.name}}(StrEnum):
     {%- for value in enum.members %}
     {{value}} = "{{value}}"
     {%- endfor %}
+{% endfor %}
+
+{% for ntuple in namedtuples | reverse %}
+class {{ntuple.name}}(NamedTuple):
+    {% for field in ntuple.fields -%}
+    {{field.name}}: {{field.type_str}}
+    {% endfor %}
 {% endfor %}
 
 {% for model in models | reverse %}


### PR DESCRIPTION
This pull request intends to fix model generation while using named tuple type defined in schema:

Example:

`money:= <tuple<amount: decimal, currency: str>>$money,`

which leads to the following error when trying to generate code:

`ValueError: Unknown type: NamedTupleType(desc_id=UUID('e25571c7-d5a0-5427-83f5-4beb3caf4636'), name='tuple<amount:std|decimal, currency:std|str>', element_types={'iso2code':...`
